### PR TITLE
Fix score read width in PlayerProperties handler (LE uint32, not byte)

### DIFF
--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -1472,7 +1472,7 @@ namespace spades {
 					int grenades = r.ReadByte();
 					int clip = r.ReadByte();
 					int reserve = r.ReadByte();
-					int score = r.ReadByte();
+					int score = r.ReadInt();
 
 					Player& p = GetPlayer(pId);
 					Weapon& w = p.GetWeapon();


### PR DESCRIPTION
Discovered while working [here](https://github.com/piqueserver/piqueserver/pull/850).

This PR should be merged before demo replaying/recording. Demo branch might have conflicts I can easily fix due to this commit.