### PR TITLE
Mods manager

### DIFF
--- a/Resources/Scripts/Gui/MainScreen/MainMenu.as
+++ b/Resources/Scripts/Gui/MainScreen/MainMenu.as
@@ -21,6 +21,7 @@
 #include "CreateProfileScreen.as"
 #include "ServerList.as"
 #include "DemoList.as"
+#include "ModList.as"
 
 namespace spades {
 
@@ -198,6 +199,23 @@ namespace spades {
 		private float demoSizeColWidth;
 		private float demoContentsWidth;
 
+		// Mods tab state
+		ModsScreenHelper@ modsHelper;
+		TabPanel@ modsPanel;
+		spades::ui::ListView@ modsList;
+		spades::ui::Button@ modsDownloadButton;
+		spades::ui::Button@ modsApplyButton;
+		spades::ui::Button@ modsResetButton;
+		spades::ui::Label@ modsStatusLabel;
+		ModsProgressBar@ modsProgressBar;
+		bool modsDownloading = false;
+		bool modsDirty = false; // enabled set changed this session; restart to apply
+		private float modsCheckColWidth;
+		private float modsOrderColWidth;
+		private float modsNameColWidth;
+		private float modsCountColWidth;
+		private float modsSizeColWidth;
+
 		private ConfigItem cg_protocolVersion("cg_protocolVersion", "3");
 		private ConfigItem cg_lastQuickConnectHost("cg_lastQuickConnectHost", "127.0.0.1");
 		private ConfigItem cg_serverlistSort("cg_serverlistSort", "16385");
@@ -212,6 +230,13 @@ namespace spades {
 			demoModeColWidth = 125.0F;
 			demoMapColWidth	 = 185.0F;
 			demoSizeColWidth = 70.0F;
+
+			modsCheckColWidth = 60.0F;
+			modsOrderColWidth = 90.0F;
+			modsNameColWidth  = 320.0F;
+			modsCountColWidth = 80.0F;
+			modsSizeColWidth  = 100.0F;
+			@modsHelper = ModsScreenHelper();
 
 			float sw = Manager.ScreenWidth;
 			float sh = Manager.ScreenHeight;
@@ -245,6 +270,10 @@ namespace spades {
 				@demoPanel = TabPanel(Manager);
 				demoPanel.Bounds = AABB2(0.0F, 0.0F, sw, sh);
 				demoPanel.Visible = false;
+
+				@modsPanel = TabPanel(Manager);
+				modsPanel.Bounds = AABB2(0.0F, 0.0F, sw, sh);
+				modsPanel.Visible = false;
 
 				// --- Server panel contents ---
 				{
@@ -477,8 +506,86 @@ namespace spades {
 					demoPanel.AddChild(demoList);
 				}
 
+				// --- Mods panel contents ---
+				{
+					@modsDownloadButton = spades::ui::Button(Manager);
+					modsDownloadButton.Caption = _Tr("MainScreen", "Download official mods…");
+					modsDownloadButton.Bounds = AABB2(contentsLeft, 200.0F, 240.0F, 30.0F);
+					@modsDownloadButton.Activated = spades::ui::EventHandler(this.OnDownloadModsPressed);
+					modsPanel.AddChild(modsDownloadButton);
+				}
+				{
+					@modsResetButton = spades::ui::Button(Manager);
+					modsResetButton.Caption = _Tr("MainScreen", "Disable all");
+					modsResetButton.Bounds = AABB2(contentsLeft + contentsWidth - 270.0F, 200.0F, 130.0F, 30.0F);
+					@modsResetButton.Activated = spades::ui::EventHandler(this.OnResetModsPressed);
+					modsPanel.AddChild(modsResetButton);
+				}
+				{
+					@modsApplyButton = spades::ui::Button(Manager);
+					modsApplyButton.Caption = _Tr("MainScreen", "Apply changes");
+					modsApplyButton.Bounds = AABB2(contentsLeft + contentsWidth - 130.0F, 200.0F, 130.0F, 30.0F);
+					@modsApplyButton.Activated = spades::ui::EventHandler(this.OnApplyModsPressed);
+					modsPanel.AddChild(modsApplyButton);
+				}
+				{
+					@modsStatusLabel = spades::ui::Label(Manager);
+					modsStatusLabel.Bounds = AABB2(contentsLeft, footerPos - 30.0F, contentsWidth, 24.0F);
+					modsStatusLabel.Text = "";
+					modsPanel.AddChild(modsStatusLabel);
+				}
+				{
+					@modsProgressBar = ModsProgressBar(Manager);
+					modsProgressBar.Bounds = AABB2(contentsLeft, footerPos - 12.0F, contentsWidth, 6.0F);
+					modsProgressBar.Visible = false;
+					modsPanel.AddChild(modsProgressBar);
+				}
+				{
+					float x = contentsLeft;
+					{
+						ModListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, modsCheckColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Status");
+						modsPanel.AddChild(header);
+						x += modsCheckColWidth;
+					}
+					{
+						ModListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, modsOrderColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Apply Order");
+						modsPanel.AddChild(header);
+						x += modsOrderColWidth;
+					}
+					{
+						ModListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, modsNameColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Mod");
+						modsPanel.AddChild(header);
+						x += modsNameColWidth;
+					}
+					{
+						ModListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, modsCountColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Paks");
+						modsPanel.AddChild(header);
+						x += modsCountColWidth;
+					}
+					{
+						ModListHeader header(Manager);
+						header.Bounds = AABB2(x, headerPos, modsSizeColWidth, headerHeight);
+						header.Text = _Tr("MainScreen", "Size");
+						modsPanel.AddChild(header);
+					}
+				}
+				{
+					@modsList = spades::ui::ListView(Manager);
+					modsList.Bounds = AABB2(contentsLeft, listPos, contentsWidth, footerPos - listPos - 44.0F);
+					modsPanel.AddChild(modsList);
+				}
+
 				AddChild(serverPanel);
 				AddChild(demoPanel);
+				AddChild(modsPanel);
 
 				// Tab strip
 				{
@@ -487,7 +594,15 @@ namespace spades {
 					AddChild(tabStrip);
 					tabStrip.AddItem(_Tr("MainScreen", "Servers"), serverPanel);
 					tabStrip.AddItem(_Tr("MainScreen", "Demos"), demoPanel);
+					tabStrip.AddItem(_Tr("MainScreen", "Mods"), modsPanel);
 					@tabStrip.Changed = spades::ui::EventHandler(this.OnTabChanged);
+				}
+
+				// Coming back from an apply-triggered relaunch — open the Mods tab.
+				if (helper.ShouldOpenModsTab()) {
+					serverPanel.Visible = false;
+					demoPanel.Visible = false;
+					modsPanel.Visible = true;
 				}
 			}
 
@@ -517,6 +632,9 @@ namespace spades {
 
 			LoadServerList();
 			LoadDemoList();
+
+			if (helper.ShouldOpenModsTab())
+				LoadModList();
 		}
 
 		void LoadServerList() {
@@ -551,6 +669,169 @@ namespace spades {
 			// Refresh demo list when switching to demos tab
 			if (demoPanel.Visible)
 				LoadDemoList();
+			if (modsPanel.Visible)
+				LoadModList();
+		}
+
+		void LoadModList() {
+			string[]@ names = modsHelper.GetModNames();
+			string[]@ enabled = modsHelper.GetEnabledMods();
+			if (names is null)
+				@names = array<string>();
+			if (enabled is null)
+				@enabled = array<string>();
+
+			// Displayed rows keep a fixed order: every mod on disk in its natural
+			// order, then any enabled mod that no longer exists (orphaned entries,
+			// shown so they can be removed). Toggling only changes a row's apply
+			// number and colour, never its position.
+			string[] list;
+			int[] orders;
+			bool[] exists;
+
+			for (uint i = 0; i < names.length; i++) {
+				int idx = EnabledIndex(enabled, names[i]);
+				list.insertLast(names[i]);
+				orders.insertLast(idx + 1); // 0 when disabled (idx == -1)
+				exists.insertLast(true);
+			}
+			// Orphaned enabled mods (enabled but no longer on disk).
+			for (uint i = 0; i < enabled.length; i++) {
+				bool onDisk = false;
+				for (uint j = 0; j < names.length; j++) {
+					if (names[j] == enabled[i]) { onDisk = true; break; }
+				}
+				if (!onDisk) {
+					list.insertLast(enabled[i]);
+					orders.insertLast(int(i) + 1);
+					exists.insertLast(false);
+				}
+			}
+
+			ModListModel model(Manager, modsHelper, list, orders, exists, modsCheckColWidth,
+			                   modsOrderColWidth, modsNameColWidth, modsCountColWidth, modsSizeColWidth);
+			@modsList.Model = model;
+			@model.ItemActivated = ModListItemEventHandler(this.OnModToggle);
+			UpdateModsStatus();
+		}
+
+		private int EnabledIndex(string[]@ enabled, string name) {
+			for (uint i = 0; i < enabled.length; i++) {
+				if (enabled[i] == name)
+					return int(i);
+			}
+			return -1;
+		}
+
+		private void UpdateModsStatus() {
+			if (modsApplyButton !is null) {
+				// Toggles already persist; Apply only restarts to make pending
+				// changes live, so it's actionable only when something changed.
+				modsApplyButton.Enable = modsDirty and not modsDownloading;
+			}
+			if (modsDownloading) {
+				int done = modsHelper.GetRefreshDone();
+				int total = modsHelper.GetRefreshTotal();
+				string item = modsHelper.GetRefreshCurrentItem();
+				if (total <= 0) {
+					modsStatusLabel.Text = _Tr("MainScreen", "Fetching mod list…");
+					modsProgressBar.Fraction = 0.0F;
+				} else {
+					string label = "" + done + " / " + total;
+					if (item.length > 0)
+						label += "  —  " + item;
+					modsStatusLabel.Text = label;
+					modsProgressBar.Fraction = float(done) / float(total);
+				}
+				modsProgressBar.Visible = true;
+				return;
+			}
+			modsProgressBar.Visible = false;
+			string msg = modsHelper.GetRefreshMessage();
+			if (msg.length > 0) {
+				modsStatusLabel.Text = msg;
+				return;
+			}
+			if (modsDirty) {
+				modsStatusLabel.Text = _Tr("MainScreen", "Press Apply changes to restart and apply your mods.");
+				return;
+			}
+			modsStatusLabel.Text = "";
+		}
+
+		private void OnDownloadModsPressed(spades::ui::UIElement@ sender) {
+			if (modsDownloading)
+				return;
+			ConfigItem indexUrl("cl_modsIndexUrl", "");
+			string body = _Tr("MainScreen", "Download the official ZeroSpades mod pack?") + "\n\n";
+			body += _Tr("MainScreen", "These are mods reviewed and hosted by the ZeroSpades team.") + "\n\n";
+			body += _Tr("MainScreen", "Source: ") + indexUrl.StringValue + "\n";
+			body += _Tr("MainScreen", "Files will be saved into your Mods/ folder, overwriting any existing copies.");
+			ConfirmScreen cs(this, body, Min(500.0F, Manager.ScreenHeight - 100.0F));
+			@cs.Closed = spades::ui::EventHandler(this.OnDownloadConfirmed);
+			cs.Run();
+		}
+
+		private void OnDownloadConfirmed(spades::ui::UIElement@ sender) {
+			ConfirmScreen@ cs = cast<ConfirmScreen>(sender);
+			if (cs is null or !cs.Result)
+				return;
+			if (modsDownloading)
+				return;
+			modsDownloading = true;
+			modsHelper.StartRefresh();
+			UpdateModsStatus();
+		}
+
+		// Apply = restart now so the enabled set is mounted. Toggles are already
+		// saved, so this just relaunches straight back into the Mods tab.
+		private void OnApplyModsPressed(spades::ui::UIElement@ sender) {
+			if (modsDownloading)
+				return;
+			helper.RelaunchForMods();
+		}
+
+		private void OnResetModsPressed(spades::ui::UIElement@ sender) {
+			ConfirmScreen cs(this, _Tr("MainScreen", "Disable all mods? This takes effect after a restart."));
+			@cs.Closed = spades::ui::EventHandler(this.OnResetConfirmed);
+			cs.Run();
+		}
+
+		private void OnResetConfirmed(spades::ui::UIElement@ sender) {
+			ConfirmScreen@ cs = cast<ConfirmScreen>(sender);
+			if (cs is null or !cs.Result)
+				return;
+			modsHelper.ClearEnabledMods();
+			modsDirty = true;
+			// Refresh the rows to clear every checkbox, not just the status line.
+			LoadModList();
+		}
+
+		// Clicking a row toggles the mod in the enabled set. The change is saved
+		// immediately and takes effect the next time the game starts.
+		private void OnModToggle(string modName) {
+			if (modsDownloading)
+				return;
+			string[]@ enabled = modsHelper.GetEnabledMods();
+			if (enabled is null)
+				@enabled = array<string>();
+			if (EnabledIndex(enabled, modName) >= 0)
+				modsHelper.DisableMod(modName);
+			else
+				modsHelper.EnableMod(modName);
+			modsDirty = true;
+			LoadModList();
+		}
+
+		private void CheckModsRefresh() {
+			if (!modsDownloading)
+				return;
+			if (modsHelper.PollRefreshState()) {
+				modsDownloading = false;
+				LoadModList();
+				return;
+			}
+			UpdateModsStatus();
 		}
 
 		void DemoListItemActivated(DemoListModel@ sender, string filename) {
@@ -837,6 +1118,7 @@ namespace spades {
 
 		void Render() {
 			CheckServerList();
+			CheckModsRefresh();
 			UIElement::Render();
 
 			// check for client error message.

--- a/Resources/Scripts/Gui/MainScreen/ModList.as
+++ b/Resources/Scripts/Gui/MainScreen/ModList.as
@@ -1,0 +1,199 @@
+/*
+ Copyright (c) 2026 Fran6nd, ZeroSpades developers.
+
+ This file is part of ZeroSpades, a fork of OpenSpades.
+
+ ZeroSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ZeroSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+namespace spades {
+	funcdef void ModListItemEventHandler(string modName);
+
+	string FormatModSize(int64 bytes) {
+		if (bytes < 1024)
+			return "" + bytes + " B";
+		if (bytes < 1024 * 1024)
+			return "" + (bytes / 1024) + " KB";
+		return "" + (bytes / (1024 * 1024)) + " MB";
+	}
+
+	class ModListItem : spades::ui::ButtonBase {
+		string modName;
+		int pakCount;
+		int64 totalSize;
+		bool enabled;   // present in the apply history
+		bool exists;    // mod still present on disk
+		int orderNum;   // 1-based apply position, 0 when disabled
+		float checkColWidth;
+		float orderColWidth;
+		float nameColWidth;
+		float countColWidth;
+		float sizeColWidth;
+
+		ModListItem(spades::ui::UIManager@ manager, string modName, int pakCount, int64 totalSize,
+		            bool enabled, bool exists, int orderNum, float checkColWidth,
+		            float orderColWidth, float nameColWidth, float countColWidth, float sizeColWidth) {
+			super(manager);
+			this.modName = modName;
+			this.pakCount = pakCount;
+			this.totalSize = totalSize;
+			this.enabled = enabled;
+			this.exists = exists;
+			this.orderNum = orderNum;
+			this.checkColWidth = checkColWidth;
+			this.orderColWidth = orderColWidth;
+			this.nameColWidth = nameColWidth;
+			this.countColWidth = countColWidth;
+			this.sizeColWidth = sizeColWidth;
+		}
+
+		void Render() {
+			Renderer@ r = Manager.Renderer;
+			Vector2 pos = ScreenPosition;
+			Vector2 size = Size;
+
+			Vector4 bgcolor = Vector4(1.0F, 1.0F, 1.0F, 0.0F);
+			// White when disabled, green when enabled, orange when enabled but
+			// the mod is no longer on disk.
+			Vector4 fgcolor = Vector4(1.0F, 1.0F, 1.0F, 1.0F);
+			if (enabled)
+				fgcolor = exists ? Vector4(0.4F, 1.0F, 0.4F, 1.0F)
+				                 : Vector4(1.0F, 0.62F, 0.1F, 1.0F);
+
+			if (Pressed and Hover) {
+				bgcolor.w = 0.3F;
+			} else if (Hover) {
+				bgcolor.w = 0.15F;
+			}
+
+			r.ColorNP = bgcolor;
+			r.DrawImage(null, AABB2(pos.x + 1.0F, pos.y + 1.0F, size.x, size.y));
+
+			// Checkbox.
+			float boxSize = 14.0F;
+			float boxX = pos.x + 5.0F;
+			float boxY = pos.y + (size.y - boxSize) * 0.5F;
+			r.ColorNP = Vector4(1.0F, 1.0F, 1.0F, 0.25F);
+			r.DrawImage(null, AABB2(boxX, boxY, boxSize, boxSize));
+			if (enabled) {
+				r.ColorNP = fgcolor;
+				r.DrawImage(null, AABB2(boxX + 3.0F, boxY + 3.0F, boxSize - 6.0F, boxSize - 6.0F));
+			}
+
+			// Apply-order number (own column, blank when disabled).
+			float x = pos.x + checkColWidth;
+			if (enabled and orderNum > 0)
+				Font.Draw("" + orderNum, Vector2(x + 2.0F, pos.y + 2.0F), 1.0F, fgcolor);
+
+			x = pos.x + checkColWidth + orderColWidth + 2.0F;
+			Font.Draw(modName, Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+			x = pos.x + checkColWidth + orderColWidth + nameColWidth + 2.0F;
+			Font.Draw(exists ? ("" + pakCount) : "—", Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+			x += countColWidth;
+			Font.Draw(exists ? FormatModSize(totalSize) : "—", Vector2(x, pos.y + 2.0F), 1.0F, fgcolor);
+		}
+	}
+
+	class ModListModel : spades::ui::ListViewModel {
+		spades::ui::UIManager@ manager;
+		ModsScreenHelper@ helper;
+		string[] list;
+		int[] orders;     // parallel to list: 1-based apply position, 0 if disabled
+		bool[] exists;    // parallel to list: mod still present on disk
+		float checkColWidth;
+		float orderColWidth;
+		float nameColWidth;
+		float countColWidth;
+		float sizeColWidth;
+		ModListItem@[] itemElements;
+
+		ModListItemEventHandler@ ItemActivated;
+
+		ModListModel(spades::ui::UIManager@ manager, ModsScreenHelper@ helper, string[]@ list,
+		             int[]@ orders, bool[]@ exists, float checkColWidth, float orderColWidth,
+		             float nameColWidth, float countColWidth, float sizeColWidth) {
+			@this.manager = manager;
+			@this.helper = helper;
+			this.list = list;
+			this.orders = orders;
+			this.exists = exists;
+			this.checkColWidth = checkColWidth;
+			this.orderColWidth = orderColWidth;
+			this.nameColWidth = nameColWidth;
+			this.countColWidth = countColWidth;
+			this.sizeColWidth = sizeColWidth;
+
+			itemElements.resize(list.length);
+		}
+
+		int NumRows { get { return int(list.length); } }
+
+		private void OnItemClicked(spades::ui::UIElement@ sender) {
+			ModListItem@ item = cast<ModListItem>(sender);
+			if (ItemActivated !is null)
+				ItemActivated(item.modName);
+		}
+
+		spades::ui::UIElement@ CreateElement(int row) {
+			if (itemElements[row] is null) {
+				string name = list[row];
+				bool ex = exists[row];
+				int count = ex ? helper.GetModPakCount(name) : 0;
+				int64 size = ex ? helper.GetModTotalSize(name) : 0;
+				ModListItem item(manager, name, count, size, orders[row] > 0, ex, orders[row],
+				                 checkColWidth, orderColWidth, nameColWidth, countColWidth, sizeColWidth);
+				@item.Activated = spades::ui::EventHandler(this.OnItemClicked);
+				@itemElements[row] = item;
+			}
+			return itemElements[row];
+		}
+
+		void RecycleElement(spades::ui::UIElement@ elem) {}
+	}
+
+	class ModListHeader : spades::ui::UIElement {
+		string Text;
+		ModListHeader(spades::ui::UIManager@ manager) { super(manager); }
+		void Render() {
+			Vector2 pos = ScreenPosition;
+			Vector2 size = Size;
+			Font.Draw(Text, pos + Vector2(2.0F, (size.y - Font.Measure(Text).y) * 0.5F), 1.0F,
+			          Vector4(1.0F, 1.0F, 1.0F, 1.0F));
+		}
+	}
+
+	// Simple fill-bar progress indicator. Fraction is clamped to [0, 1].
+	class ModsProgressBar : spades::ui::UIElement {
+		float Fraction = 0.0F;
+
+		ModsProgressBar(spades::ui::UIManager@ manager) { super(manager); }
+
+		void Render() {
+			Renderer@ r = Manager.Renderer;
+			Vector2 pos = ScreenPosition;
+			Vector2 size = Size;
+
+			float f = Fraction;
+			if (f < 0.0F) f = 0.0F;
+			if (f > 1.0F) f = 1.0F;
+
+			r.ColorNP = Vector4(1.0F, 1.0F, 1.0F, 0.12F);
+			r.DrawImage(null, AABB2(pos.x, pos.y, size.x, size.y));
+
+			r.ColorNP = Vector4(1.0F, 1.0F, 1.0F, 0.55F);
+			r.DrawImage(null, AABB2(pos.x, pos.y, size.x * f, size.y));
+		}
+	}
+}

--- a/Sources/Core/Debug.cpp
+++ b/Sources/Core/Debug.cpp
@@ -202,6 +202,13 @@ namespace spades {
 		accumlatedLog.clear();
 	}
 
+	void StopLog() {
+		if (logStream) {
+			logStream->Flush();
+			logStream.reset(); // closes the underlying file handle
+		}
+	}
+
 	void GetBufferedLogLines(stmp::dyn_function<void(std::string)>&& cb) {
 		BoundedLogBuffer tmp;
 

--- a/Sources/Core/Debug.h
+++ b/Sources/Core/Debug.h
@@ -84,6 +84,12 @@ namespace spades {
 	} // namespace reflection
 	void StartLog();
 
+	// Flush and release the log file so its handle is no longer held. Used
+	// before relaunching the process so the new instance can open the log
+	// without colliding with this one on Windows. Later log messages still go
+	// to stdout/console but are no longer written to the file.
+	void StopLog();
+
 	void LogMessage(const char* file, int line, const char* format, ...)
 #ifdef __GNUC__
 	  __attribute__((format(printf, 3, 4)))

--- a/Sources/Core/ZipFileSystem.cpp
+++ b/Sources/Core/ZipFileSystem.cpp
@@ -409,6 +409,14 @@ namespace spades {
 		return lst;
 	}
 
+	std::vector<std::string> ZipFileSystem::GetAllFiles() {
+		std::vector<std::string> out;
+		out.reserve(files.size());
+		for (const auto& kv : files)
+			out.push_back(kv.first);
+		return out;
+	}
+
 	bool ZipFileSystem::MoveToFile(const char* fn) {
 		SPADES_MARK_FUNCTION();
 

--- a/Sources/Core/ZipFileSystem.h
+++ b/Sources/Core/ZipFileSystem.h
@@ -65,6 +65,11 @@ namespace spades {
 
 		std::vector<std::string> EnumFiles(const char*) override;
 
+		// Returns every entry path in the archive (lowercased, forward slashes).
+		// EnumFiles("") returns nothing because its filter wants a directory
+		// prefix; this is the way to iterate all entries for a merge.
+		std::vector<std::string> GetAllFiles();
+
 		std::unique_ptr<IStream> OpenForReading(const char*) override;
 		std::unique_ptr<IStream> OpenForWriting(const char*) override;
 		bool FileExists(const char*) override;

--- a/Sources/Gui/Main.cpp
+++ b/Sources/Gui/Main.cpp
@@ -48,6 +48,7 @@
 #include <Core/Thread.h>
 #include <Core/ZipFileSystem.h>
 #include <Gui/ConsoleScreen.h>
+#include <Gui/ModsScreenHelper.h>
 #include <Gui/StartupScreen.h>
 #include <ZeroSpades.h>
 
@@ -237,6 +238,10 @@ namespace {
 				}
 				return 0;
 			}
+			if (!strcasecmp(a, "--open-mods")) {
+				spades::g_openModsTab = true;
+				return ++i;
+			}
 		}
 
 		return 0;
@@ -245,6 +250,8 @@ namespace {
 
 namespace spades {
 	std::string g_userResourceDirectory;
+	std::string g_executablePath;
+	bool g_openModsTab = false;
 
 	void StartClient(const spades::ServerAddress& addr) {
 		class ConcreteRunner : public spades::gui::Runner {
@@ -304,6 +311,90 @@ namespace spades {
 	}
 } // namespace spades
 
+#ifndef _WIN32
+#include <spawn.h>
+#include <unistd.h>
+extern char** environ;
+#else
+#include <process.h>
+#endif
+
+namespace spades {
+	void RelaunchForMods() {
+		// Spawn a new instance of the same binary with --open-mods, then exit.
+		Settings::GetInstance()->Flush();
+
+		// Release every file handle this process holds before spawning the
+		// replacement. On Windows a file open for writing without shared access
+		// can't be reopened by another process, so if the old process still held
+		// SystemMessages.log the fresh instance would fail to start logging. By
+		// closing first, the new process always finds the files free — no race,
+		// no startup delay.
+		StopLog();
+		FileManager::Close();
+
+#ifdef _WIN32
+		std::wstring exe;
+		{
+			auto* ws = (wchar_t*)SDL_iconv_string(
+			  "UCS-2-INTERNAL", "UTF-8", g_executablePath.c_str(),
+			  g_executablePath.size() + 1);
+			if (ws) {
+				exe.assign(ws);
+				SDL_free(ws);
+			}
+		}
+		std::wstring cmd = L"\"" + exe + L"\" --open-mods";
+		STARTUPINFOW si{};
+		si.cb = sizeof(si);
+		PROCESS_INFORMATION pi{};
+		if (CreateProcessW(exe.c_str(), &cmd[0], nullptr, nullptr, FALSE,
+		                   0, nullptr, nullptr, &si, &pi)) {
+			CloseHandle(pi.hThread);
+			CloseHandle(pi.hProcess);
+		}
+#elif defined(__APPLE__)
+		// Prefer launching the .app bundle via `open -n` so the new process
+		// becomes a proper foreground application; fall back to executing
+		// the binary directly if we can't find the bundle.
+		std::string base = g_executablePath;
+		std::string appPath;
+		auto pos = base.find(".app/");
+		if (pos != std::string::npos)
+			appPath = base.substr(0, pos + 4);
+
+		std::vector<const char*> args;
+		if (!appPath.empty()) {
+			args.push_back("open");
+			args.push_back("-n");
+			args.push_back(appPath.c_str());
+			args.push_back("--args");
+			args.push_back("--open-mods");
+			args.push_back(nullptr);
+			pid_t pid = 0;
+			posix_spawnp(&pid, args[0], nullptr, nullptr,
+			             const_cast<char**>(args.data()), environ);
+		} else {
+			args.push_back(g_executablePath.c_str());
+			args.push_back("--open-mods");
+			args.push_back(nullptr);
+			pid_t pid = 0;
+			posix_spawnp(&pid, args[0], nullptr, nullptr,
+			             const_cast<char**>(args.data()), environ);
+		}
+#else
+		const char* argv[] = {g_executablePath.c_str(), "--open-mods", nullptr};
+		pid_t pid = 0;
+		posix_spawnp(&pid, argv[0], nullptr, nullptr,
+		             const_cast<char**>(argv), environ);
+#endif
+
+		// Skip atexit handlers — SDL/GL teardown can stall here, and the
+		// fresh process is already on its way.
+		_exit(0);
+	}
+} // namespace spades
+
 static uLong computeCrc32ForStream(spades::IStream* s) {
 	uLong crc = crc32(0L, Z_NULL, 0);
 
@@ -332,6 +423,9 @@ int main(int argc, char** argv) {
 #ifdef WIN32
 	SetUnhandledExceptionFilter(UnhandledExceptionProc);
 #endif
+
+	if (argc > 0 && argv[0])
+		spades::g_executablePath = argv[0];
 
 	for (int i = 1; i < argc;) {
 		int ret = handleCommandLineArgument(argc, argv, i);
@@ -604,6 +698,26 @@ int main(int argc, char** argv) {
 			for (size_t i = 0; i < fssImportant.size(); i++)
 				spades::FileManager::PrependFileSystem(fssImportant[i]);
 		}
+
+		// Mount enabled mods as an overlay on top of the base paks. Each enabled
+		// mod's pak(s) live in Mods/ and are prepended so they take priority over
+		// the base paks; the set is mounted in enabled order so the last-enabled
+		// mod ends up on top and wins conflicts. The shipped install paks are
+		// never modified — changes to the enabled set take effect on next launch.
+		{
+			std::vector<std::string> modPaks =
+			  spades::gui::ModsScreenHelper::GetEnabledModPakPaths();
+			for (const std::string& path : modPaks) {
+				try {
+					auto stream = spades::FileManager::OpenForReading(path.c_str());
+					spades::FileManager::PrependFileSystem(
+					  new spades::ZipFileSystem(stream.release()));
+					SPLog("Mod pak mounted: %s", path.c_str());
+				} catch (const std::exception& ex) {
+					SPLog("Mod pak failed to mount: %s: %s", path.c_str(), ex.what());
+				}
+			}
+		}
 		pumpEvents();
 
 		// initialize localization system
@@ -638,7 +752,8 @@ int main(int argc, char** argv) {
 			SPLog("Starting demo replay: %s", g_replayDemoPath.c_str());
 			spades::StartDemoReplay(g_replayDemoPath);
 		} else if (!g_autoconnect) {
-			if (!((int)cl_showStartupWindow != 0 || splashWindow->IsStartupScreenRequested())) {
+			if (spades::g_openModsTab ||
+			    !((int)cl_showStartupWindow != 0 || splashWindow->IsStartupScreenRequested())) {
 				splashWindow.reset();
 
 				SPLog("Starting main screen");

--- a/Sources/Gui/Main.h
+++ b/Sources/Gui/Main.h
@@ -28,7 +28,16 @@ namespace spades {
 	/** The path to the user resource directory. Can be empty. */
 	extern std::string g_userResourceDirectory;
 
+	/** argv[0] captured at startup, used to relaunch the program. */
+	extern std::string g_executablePath;
+
+	/** Set by --open-mods. Skips the startup window and selects the Mods tab. */
+	extern bool g_openModsTab;
+
 	void StartClient(const ServerAddress&);
 	void StartMainScreen();
 	void StartDemoReplay(const std::string& demoPath);
+
+	/** Relaunch the program with --open-mods, then exit the current process. */
+	void RelaunchForMods();
 } // namespace spades

--- a/Sources/Gui/MainScreenHelper.cpp
+++ b/Sources/Gui/MainScreenHelper.cpp
@@ -30,6 +30,7 @@
 #include <curl/curl.h>
 #include <json/json.h>
 
+#include "Main.h"
 #include "MainScreen.h"
 #include "MainScreenHelper.h"
 #include <Client/DemoRecorder.h>
@@ -473,6 +474,9 @@ namespace spades {
 		bool MainScreenHelper::RenameDemo(const std::string& oldName, const std::string& newName) {
 			return FileManager::RenameFile(oldName.c_str(), newName.c_str());
 		}
+
+		bool MainScreenHelper::ShouldOpenModsTab() { return spades::g_openModsTab; }
+		void MainScreenHelper::RelaunchForMods() { spades::RelaunchForMods(); }
 
 		std::string MainScreenHelper::GetPendingErrorMessage() {
 			std::string s = errorMessage;

--- a/Sources/Gui/MainScreenHelper.h
+++ b/Sources/Gui/MainScreenHelper.h
@@ -116,6 +116,9 @@ namespace spades {
 			int64_t GetDemoFileSize(const std::string& filename);
 			bool DeleteDemo(const std::string& filename);
 			bool RenameDemo(const std::string& oldName, const std::string& newName);
+
+			bool ShouldOpenModsTab();
+			void RelaunchForMods();
 		};
 	}
 }

--- a/Sources/Gui/ModsScreenHelper.cpp
+++ b/Sources/Gui/ModsScreenHelper.cpp
@@ -1,0 +1,602 @@
+/*
+ Copyright (c) 2026 Fran6nd, ZeroSpades developers.
+
+ This file is part of ZeroSpades, a fork of OpenSpades.
+
+ ZeroSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ZeroSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include "ModsScreenHelper.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/stat.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
+#include <curl/curl.h>
+#include <json/json.h>
+
+#include "Main.h"
+#include <Core/Debug.h>
+#include <Core/DynamicMemoryStream.h>
+#include <Core/Exception.h>
+#include <Core/FileManager.h>
+#include <Core/IStream.h>
+#include <Core/Settings.h>
+#include <Core/Strings.h>
+#include <Core/Thread.h>
+#include <Core/ZipFileSystem.h>
+#include <ScriptBindings/ScriptManager.h>
+#include <ZeroSpades.h>
+
+DEFINE_SPADES_SETTING(cl_modsIndexUrl,
+                      "https://api.github.com/repos/zerospades/zerospades-paks/contents/");
+
+namespace spades {
+	namespace gui {
+
+		namespace {
+			constexpr const char* kModsDir = "Mods";
+			// The enabled set lives here, at the resource root: one mod name per
+			// line, in apply order (bottom wins conflicts). No build stamp — mods
+			// are mounted as a startup overlay, never merged onto disk, so the
+			// base paks can't go stale.
+			constexpr const char* kEnabledFile = "EnabledMods.txt";
+
+			struct CURLDeleter {
+				void operator()(CURL* p) const {
+					if (p)
+						curl_easy_cleanup(p);
+				}
+			};
+
+			std::string ToLower(const std::string& s) {
+				std::string out = s;
+				std::transform(out.begin(), out.end(), out.begin(),
+				               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+				return out;
+			}
+
+			bool EndsWithPak(const std::string& s) {
+				std::string l = ToLower(s);
+				return l.size() >= 4 && (l.compare(l.size() - 4, 4, ".pak") == 0 ||
+				                         l.compare(l.size() - 4, 4, ".zip") == 0);
+			}
+
+			void MakeDir(const std::string& path) {
+#ifdef _WIN32
+				_mkdir(path.c_str());
+#else
+				::mkdir(path.c_str(), 0775);
+#endif
+			}
+
+			void EnsureDir(const std::string& path) {
+				// Iteratively create each prefix.
+				for (std::size_t i = 1; i < path.size(); ++i) {
+					if (path[i] == '/' || path[i] == '\\')
+						MakeDir(path.substr(0, i));
+				}
+				MakeDir(path);
+			}
+
+			std::string EnabledFileAbs() {
+				return std::string(spades::g_userResourceDirectory) + "/" + kEnabledFile;
+			}
+
+			// The ordered enabled mod names, one per line. Empty if the file is
+			// absent. Top = applied first, bottom wins conflicts.
+			std::vector<std::string> ReadEnabled() {
+				std::vector<std::string> out;
+				std::FILE* f = std::fopen(EnabledFileAbs().c_str(), "rb");
+				if (!f)
+					return out;
+				std::string all;
+				char buf[4096];
+				std::size_t rd;
+				while ((rd = std::fread(buf, 1, sizeof(buf), f)) > 0)
+					all.append(buf, rd);
+				std::fclose(f);
+				std::size_t start = 0;
+				while (start <= all.size()) {
+					std::size_t nl = all.find('\n', start);
+					std::string line = all.substr(
+					  start, (nl == std::string::npos ? all.size() : nl) - start);
+					// Strip only the CR of a CRLF — a trailing space can be part
+					// of a real mod name, so leave it intact.
+					while (!line.empty() && line.back() == '\r')
+						line.pop_back();
+					if (!line.empty())
+						out.push_back(line);
+					if (nl == std::string::npos)
+						break;
+					start = nl + 1;
+				}
+				return out;
+			}
+
+			// Overwrite the enabled file with the given ordered names. Best-effort.
+			void WriteEnabled(const std::vector<std::string>& lines) {
+				if (std::FILE* f = std::fopen(EnabledFileAbs().c_str(), "wb")) {
+					for (const std::string& line : lines) {
+						std::fputs(line.c_str(), f);
+						std::fputc('\n', f);
+					}
+					std::fclose(f);
+				}
+			}
+
+			std::int64_t FileSizeAbs(const std::string& path) {
+				struct stat st;
+				if (::stat(path.c_str(), &st) == 0)
+					return static_cast<std::int64_t>(st.st_size);
+				return -1;
+			}
+
+			std::vector<std::string> ListDir(const std::string& path) {
+				std::vector<std::string> out;
+#ifdef _WIN32
+				WIN32_FIND_DATAA fd;
+				HANDLE h = FindFirstFileA((path + "\\*").c_str(), &fd);
+				if (h == INVALID_HANDLE_VALUE)
+					return out;
+				do {
+					if (std::strcmp(fd.cFileName, ".") == 0 ||
+					    std::strcmp(fd.cFileName, "..") == 0)
+						continue;
+					out.emplace_back(fd.cFileName);
+				} while (FindNextFileA(h, &fd));
+				FindClose(h);
+#else
+				DIR* d = ::opendir(path.c_str());
+				if (!d)
+					return out;
+				while (auto* e = ::readdir(d)) {
+					if (e->d_name[0] == '.')
+						continue;
+					out.emplace_back(e->d_name);
+				}
+				::closedir(d);
+#endif
+				return out;
+			}
+
+			bool IsDirAbs(const std::string& path) {
+				struct stat st;
+				if (::stat(path.c_str(), &st) != 0)
+					return false;
+				return (st.st_mode & S_IFDIR) != 0;
+			}
+
+			std::string UserRoot() { return spades::g_userResourceDirectory; }
+			std::string ModsRootAbs() { return UserRoot() + "/" + kModsDir; }
+
+			std::size_t CurlWriteToString(void* ptr, std::size_t size, std::size_t nmemb,
+			                              void* userdata) {
+				std::string* s = static_cast<std::string*>(userdata);
+				std::size_t n = size * nmemb;
+				s->append(static_cast<char*>(ptr), n);
+				return n;
+			}
+
+			std::size_t CurlWriteToFile(void* ptr, std::size_t size, std::size_t nmemb,
+			                            void* userdata) {
+				std::FILE* f = static_cast<std::FILE*>(userdata);
+				// fwrite returns the number of whole items written; curl wants the
+				// number of bytes handled, so scale back up by the item size.
+				std::size_t itemsWritten = std::fwrite(ptr, size, nmemb, f);
+				return itemsWritten * size;
+			}
+
+			// HTTP GET into a string. Returns "" on success, otherwise an error
+			// description. User-Agent is required by the GitHub API.
+			std::string HttpGetText(const std::string& url, std::string& out) {
+				std::unique_ptr<CURL, CURLDeleter> h{curl_easy_init()};
+				if (!h)
+					return "curl_easy_init failed";
+				curl_easy_setopt(h.get(), CURLOPT_URL, url.c_str());
+				curl_easy_setopt(h.get(), CURLOPT_USERAGENT, PACKAGE_STRING);
+				curl_easy_setopt(h.get(), CURLOPT_FOLLOWLOCATION, 1L);
+				curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, CurlWriteToString);
+				curl_easy_setopt(h.get(), CURLOPT_WRITEDATA, &out);
+				curl_easy_setopt(h.get(), CURLOPT_CONNECTTIMEOUT, 30L);
+				curl_easy_setopt(h.get(), CURLOPT_LOW_SPEED_TIME, 30L);
+				curl_easy_setopt(h.get(), CURLOPT_LOW_SPEED_LIMIT, 15L);
+				CURLcode rc = curl_easy_perform(h.get());
+				if (rc != CURLE_OK)
+					return curl_easy_strerror(rc);
+				long code = 0;
+				curl_easy_getinfo(h.get(), CURLINFO_RESPONSE_CODE, &code);
+				if (code >= 400)
+					return Format("HTTP {0}", code);
+				return std::string{};
+			}
+
+			std::string HttpDownloadToFile(const std::string& url,
+			                               const std::string& destAbs) {
+				std::FILE* f = std::fopen(destAbs.c_str(), "wb");
+				if (!f)
+					return Format("Cannot create '{0}'", destAbs);
+				std::unique_ptr<CURL, CURLDeleter> h{curl_easy_init()};
+				if (!h) {
+					std::fclose(f);
+					std::remove(destAbs.c_str());
+					return "curl_easy_init failed";
+				}
+				curl_easy_setopt(h.get(), CURLOPT_URL, url.c_str());
+				curl_easy_setopt(h.get(), CURLOPT_USERAGENT, PACKAGE_STRING);
+				curl_easy_setopt(h.get(), CURLOPT_FOLLOWLOCATION, 1L);
+				curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, CurlWriteToFile);
+				curl_easy_setopt(h.get(), CURLOPT_WRITEDATA, f);
+				curl_easy_setopt(h.get(), CURLOPT_CONNECTTIMEOUT, 30L);
+				CURLcode rc = curl_easy_perform(h.get());
+				long code = 0;
+				curl_easy_getinfo(h.get(), CURLINFO_RESPONSE_CODE, &code);
+				std::fclose(f);
+				if (rc != CURLE_OK) {
+					std::remove(destAbs.c_str());
+					return curl_easy_strerror(rc);
+				}
+				if (code >= 400) {
+					std::remove(destAbs.c_str());
+					return Format("HTTP {0}", code);
+				}
+				return std::string{};
+			}
+		} // namespace
+
+		class ModsScreenHelper::RefreshQuery final : public Thread {
+			Handle<ModsScreenHelper> owner;
+
+			void Done(const std::string& msg) {
+				owner->resultCell.store(std::make_unique<std::string>(msg));
+				owner = nullptr;
+			}
+
+			void SetCurrent(const std::string& s) {
+				std::lock_guard<std::mutex> lk(owner->progressMutex);
+				owner->progressItem = s;
+			}
+
+			// Two-pass: first walk the listing to count downloadable items, then
+			// walk again to actually download. Lets the UI show a real fraction.
+			void CountInto(const Json::Value& root, int& counter) {
+				if (!root.isArray())
+					return;
+				for (const auto& entry : root) {
+					std::string type = entry.get("type", "").asString();
+					std::string name = entry.get("name", "").asString();
+					if (type == "file" && EndsWithPak(name))
+						++counter;
+				}
+			}
+
+			std::string FetchOneLevel(const Json::Value& root, const std::string& dirAbs) {
+				EnsureDir(dirAbs);
+				for (const auto& entry : root) {
+					std::string type = entry.get("type", "").asString();
+					std::string name = entry.get("name", "").asString();
+					if (type != "file" || !EndsWithPak(name))
+						continue;
+					std::string dl = entry.get("download_url", "").asString();
+					if (dl.empty())
+						continue;
+					SetCurrent(name);
+					std::string partial = dirAbs + "/" + name + ".partial";
+					std::string finalPath = dirAbs + "/" + name;
+					std::string e = HttpDownloadToFile(dl, partial);
+					if (!e.empty())
+						return Format("Download '{0}': {1}", name, e);
+					std::remove(finalPath.c_str());
+					if (std::rename(partial.c_str(), finalPath.c_str()) != 0) {
+						std::remove(partial.c_str());
+						return Format("Rename '{0}' failed", name);
+					}
+					++owner->progressDone;
+				}
+				return std::string{};
+			}
+
+		public:
+			explicit RefreshQuery(ModsScreenHelper* o) : owner{o} {}
+
+			void Run() override {
+				try {
+					owner->progressTotal.store(0);
+					owner->progressDone.store(0);
+					SetCurrent("");
+					EnsureDir(ModsRootAbs());
+
+					// Fetch and parse the root listing.
+					std::string body;
+					std::string err = HttpGetText(cl_modsIndexUrl.CString(), body);
+					if (!err.empty()) {
+						Done(Format("List '{0}': {1}", std::string(cl_modsIndexUrl.CString()), err));
+						return;
+					}
+					Json::Reader reader;
+					Json::Value root;
+					if (!reader.parse(body, root, false) || !root.isArray()) {
+						Done("Index parse failed (expected JSON array)");
+						return;
+					}
+
+					// First, collect sub-listings (folder mods) and count
+					// everything that will be downloaded so progressTotal is
+					// correct from the start.
+					struct SubListing {
+						std::string name;
+						Json::Value items;
+					};
+					std::vector<SubListing> subs;
+					int total = 0;
+					CountInto(root, total);
+					for (const auto& entry : root) {
+						if (entry.get("type", "").asString() != "dir")
+							continue;
+						std::string url = entry.get("url", "").asString();
+						std::string name = entry.get("name", "").asString();
+						if (url.empty() || name.empty())
+							continue;
+						std::string sb;
+						std::string e = HttpGetText(url, sb);
+						if (!e.empty()) {
+							Done(Format("List '{0}': {1}", name, e));
+							return;
+						}
+						Json::Value sroot;
+						if (!reader.parse(sb, sroot, false) || !sroot.isArray())
+							continue;
+						SubListing s;
+						s.name = name;
+						s.items = sroot;
+						CountInto(sroot, total);
+						subs.push_back(std::move(s));
+					}
+					owner->progressTotal.store(total);
+
+					// Now actually download. Loose paks land at Mods/<name>;
+					// folder mods land at Mods/<folder>/<name>.
+					std::string e = FetchOneLevel(root, ModsRootAbs());
+					if (!e.empty()) {
+						Done(e);
+						return;
+					}
+					for (const auto& s : subs) {
+						std::string sub = ModsRootAbs() + "/" + s.name;
+						e = FetchOneLevel(s.items, sub);
+						if (!e.empty()) {
+							Done(e);
+							return;
+						}
+					}
+					Done(std::string{});
+				} catch (const std::exception& ex) {
+					Done(ex.what());
+				} catch (...) {
+					Done("Unknown error");
+				}
+			}
+		};
+
+		ModsScreenHelper::ModsScreenHelper()
+		    : query(nullptr), modsCached(false), progressTotal(0), progressDone(0) {
+			SPADES_MARK_FUNCTION();
+		}
+
+		int ModsScreenHelper::GetRefreshTotal() { return progressTotal.load(); }
+		int ModsScreenHelper::GetRefreshDone() { return progressDone.load(); }
+		std::string ModsScreenHelper::GetRefreshCurrentItem() {
+			std::lock_guard<std::mutex> lk(progressMutex);
+			return progressItem;
+		}
+
+		ModsScreenHelper::~ModsScreenHelper() {
+			SPADES_MARK_FUNCTION();
+			if (query)
+				query->MarkForAutoDeletion();
+		}
+
+		void ModsScreenHelper::StartRefresh() {
+			SPADES_MARK_FUNCTION();
+			if (query)
+				return; // already running
+			lastMessage.clear();
+			query = new RefreshQuery(this);
+			query->Start();
+		}
+
+		bool ModsScreenHelper::PollRefreshState() {
+			SPADES_MARK_FUNCTION();
+			auto cell = resultCell.take();
+			if (cell) {
+				lastMessage = *cell;
+				if (query) {
+					query->MarkForAutoDeletion();
+					query = nullptr;
+				}
+				modsCached = false; // freshen cache after download
+			}
+			return query == nullptr;
+		}
+
+		std::string ModsScreenHelper::GetRefreshMessage() { return lastMessage; }
+
+		void ModsScreenHelper::RebuildModsCache() {
+			mods.clear();
+			std::string root = ModsRootAbs();
+			if (!IsDirAbs(root)) {
+				modsCached = true;
+				return;
+			}
+			for (const std::string& entry : ListDir(root)) {
+				std::string abs = root + "/" + entry;
+				if (IsDirAbs(abs)) {
+					// Multi-pak mod: a folder containing one or more .pak files.
+					ModEntry m;
+					m.name = entry;
+					m.isFolder = true;
+					for (const std::string& f : ListDir(abs)) {
+						if (!EndsWithPak(f))
+							continue;
+						m.paks.push_back(f);
+						std::int64_t sz = FileSizeAbs(abs + "/" + f);
+						if (sz > 0)
+							m.totalSize += sz;
+					}
+					std::sort(m.paks.begin(), m.paks.end());
+					if (!m.paks.empty())
+						mods.push_back(std::move(m));
+				} else if (EndsWithPak(entry)) {
+					// Loose pak at the root: treat as a single-pak mod named
+					// after the file (extension included for clarity).
+					ModEntry m;
+					m.name = entry;
+					m.isFolder = false;
+					m.paks.push_back(entry);
+					std::int64_t sz = FileSizeAbs(abs);
+					if (sz > 0)
+						m.totalSize = sz;
+					mods.push_back(std::move(m));
+				}
+			}
+			std::sort(mods.begin(), mods.end(),
+			          [](const ModEntry& a, const ModEntry& b) { return a.name < b.name; });
+			modsCached = true;
+		}
+
+		const ModsScreenHelper::ModEntry*
+		ModsScreenHelper::FindMod(const std::string& name) const {
+			for (const ModEntry& m : mods)
+				if (m.name == name)
+					return &m;
+			return nullptr;
+		}
+
+		CScriptArray* ModsScreenHelper::GetModNames() {
+			if (!modsCached)
+				RebuildModsCache();
+			asIScriptEngine* eng = ScriptManager::GetInstance()->GetEngine();
+			asITypeInfo* t = eng->GetTypeInfoByDecl("array<string>");
+			SPAssert(t != nullptr);
+			CScriptArray* arr = CScriptArray::Create(t, static_cast<asUINT>(mods.size()));
+			for (std::size_t i = 0; i < mods.size(); ++i)
+				arr->SetValue(static_cast<asUINT>(i), &mods[i].name);
+			return arr;
+		}
+
+		int ModsScreenHelper::GetModPakCount(std::string modName) {
+			if (!modsCached)
+				RebuildModsCache();
+			const ModEntry* m = FindMod(modName);
+			return m ? static_cast<int>(m->paks.size()) : 0;
+		}
+
+		std::int64_t ModsScreenHelper::GetModTotalSize(std::string modName) {
+			if (!modsCached)
+				RebuildModsCache();
+			const ModEntry* m = FindMod(modName);
+			return m ? m->totalSize : 0;
+		}
+
+		CScriptArray* ModsScreenHelper::GetModContents(std::string modName) {
+			if (!modsCached)
+				RebuildModsCache();
+			std::vector<std::string> out;
+			const ModEntry* m = FindMod(modName);
+			if (m) {
+				for (const std::string& pak : m->paks) {
+					std::string overlayPath = m->isFolder
+					    ? ("Mods/" + m->name + "/" + pak)
+					    : ("Mods/" + pak);
+					try {
+						auto stream = FileManager::OpenForReading(overlayPath.c_str());
+						ZipFileSystem zfs(stream.release());
+						for (const std::string& f : zfs.GetAllFiles())
+							out.push_back(pak + ": " + f);
+					} catch (const std::exception& ex) {
+						out.push_back(pak + ": <unreadable: " + ex.what() + ">");
+					}
+				}
+			}
+			std::sort(out.begin(), out.end());
+			asIScriptEngine* eng = ScriptManager::GetInstance()->GetEngine();
+			asITypeInfo* t = eng->GetTypeInfoByDecl("array<string>");
+			SPAssert(t != nullptr);
+			CScriptArray* arr = CScriptArray::Create(t, static_cast<asUINT>(out.size()));
+			for (std::size_t i = 0; i < out.size(); ++i)
+				arr->SetValue(static_cast<asUINT>(i), &out[i]);
+			return arr;
+		}
+
+		CScriptArray* ModsScreenHelper::GetEnabledMods() {
+			std::vector<std::string> list = ReadEnabled();
+			asIScriptEngine* eng = ScriptManager::GetInstance()->GetEngine();
+			asITypeInfo* t = eng->GetTypeInfoByDecl("array<string>");
+			SPAssert(t != nullptr);
+			CScriptArray* arr = CScriptArray::Create(t, static_cast<asUINT>(list.size()));
+			for (std::size_t i = 0; i < list.size(); ++i)
+				arr->SetValue(static_cast<asUINT>(i), &list[i]);
+			return arr;
+		}
+
+		// Enable a mod: drop any existing entry and append it at the end so it is
+		// applied last (and so wins conflicts). Persisted immediately; it takes
+		// effect on the next launch, when the overlay is mounted.
+		void ModsScreenHelper::EnableMod(std::string modName) {
+			std::vector<std::string> list = ReadEnabled();
+			list.erase(std::remove(list.begin(), list.end(), modName), list.end());
+			list.push_back(modName);
+			WriteEnabled(list);
+		}
+
+		void ModsScreenHelper::DisableMod(std::string modName) {
+			std::vector<std::string> list = ReadEnabled();
+			list.erase(std::remove(list.begin(), list.end(), modName), list.end());
+			WriteEnabled(list);
+		}
+
+		void ModsScreenHelper::ClearEnabledMods() { WriteEnabled({}); }
+
+		std::vector<std::string> ModsScreenHelper::GetEnabledModPakPaths() {
+			// Resolve the enabled names to pak paths relative to the resource
+			// root, in enabled order. Runs at startup before any instance
+			// exists, so a throwaway helper does the directory scan. Names with
+			// no matching mod on disk are skipped.
+			Handle<ModsScreenHelper> h = Handle<ModsScreenHelper>::New();
+			h->RebuildModsCache();
+			std::vector<std::string> out;
+			for (const std::string& name : ReadEnabled()) {
+				const ModEntry* m = h->FindMod(name);
+				if (m == nullptr)
+					continue;
+				for (const std::string& pak : m->paks)
+					out.push_back(m->isFolder
+					    ? (std::string(kModsDir) + "/" + m->name + "/" + pak)
+					    : (std::string(kModsDir) + "/" + pak));
+			}
+			return out;
+		}
+
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ModsScreenHelper.h
+++ b/Sources/Gui/ModsScreenHelper.h
@@ -1,0 +1,106 @@
+/*
+ Copyright (c) 2026 Fran6nd, ZeroSpades developers.
+
+ This file is part of ZeroSpades, a fork of OpenSpades.
+
+ ZeroSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ZeroSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <Core/RefCountedObject.h>
+#include <Core/TMPUtils.h>
+#include <ScriptBindings/ScriptManager.h>
+
+#include <AngelScript/addons/scriptarray.h>
+
+namespace spades {
+	namespace gui {
+
+		class ModsScreenHelper : public RefCountedObject {
+		public:
+			ModsScreenHelper();
+
+			// Async fetch of the official mod repo listing + download of every
+			// listed pak into the user Mods/ folder: loose paks land at
+			// Mods/<name>, folder mods at Mods/<folder>/<name>.
+			void StartRefresh();
+			bool PollRefreshState();
+			std::string GetRefreshMessage();
+
+			// Live progress while a refresh is running.
+			int GetRefreshTotal();
+			int GetRefreshDone();
+			std::string GetRefreshCurrentItem();
+
+			CScriptArray* GetModNames();
+			int GetModPakCount(std::string modName);
+			int64_t GetModTotalSize(std::string modName);
+			CScriptArray* GetModContents(std::string modName);
+
+			// The enabled set: ordered mod names, top applied first, bottom wins
+			// conflicts. Toggling persists immediately; the change takes effect
+			// the next time the game starts (mods are mounted as a startup
+			// overlay — see GetEnabledModPakPaths).
+			CScriptArray* GetEnabledMods();
+			void EnableMod(std::string modName);
+			void DisableMod(std::string modName);
+
+			// Disable every mod (clears the enabled set). Always succeeds.
+			void ClearEnabledMods();
+
+			// Startup: the ordered pak paths to mount as an overlay, relative to
+			// the resource root (e.g. "Mods/<folder>/<x>.pak"). In enabled order
+			// so the caller can prepend each in turn — last-enabled ends up on
+			// top and wins conflicts. Mods missing from disk are skipped.
+			static std::vector<std::string> GetEnabledModPakPaths();
+
+		protected:
+			~ModsScreenHelper();
+
+		private:
+			class RefreshQuery;
+
+			struct ModEntry {
+				std::string name;
+				bool isFolder = false; // true: Mods/<name>/*.pak; false: Mods/<name> (single pak)
+				std::vector<std::string> paks;
+				std::int64_t totalSize = 0;
+			};
+
+			stmp::atomic_unique_ptr<std::string> resultCell;
+			RefreshQuery* query;
+			std::string lastMessage;
+			std::vector<ModEntry> mods;
+			bool modsCached;
+
+			std::atomic<int> progressTotal;
+			std::atomic<int> progressDone;
+			std::mutex progressMutex;
+			std::string progressItem;
+
+			void RebuildModsCache();
+			const ModEntry* FindMod(const std::string& name) const;
+		};
+
+	} // namespace gui
+} // namespace spades

--- a/Sources/ScriptBindings/MainScreenHelper.cpp
+++ b/Sources/ScriptBindings/MainScreenHelper.cpp
@@ -105,6 +105,14 @@ namespace spades {
 												  asMETHOD(gui::MainScreenHelper, RenameDemo),
 												  asCALL_THISCALL);
 					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "bool ShouldOpenModsTab()",
+					                              asMETHOD(gui::MainScreenHelper, ShouldOpenModsTab),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod("MainScreenHelper", "void RelaunchForMods()",
+					                              asMETHOD(gui::MainScreenHelper, RelaunchForMods),
+					                              asCALL_THISCALL);
+					manager->CheckError(r);
 					r = eng->RegisterObjectBehaviour(
 					  "MainScreenServerItem", asBEHAVE_ADDREF, "void f()",
 					  asMETHOD(gui::MainScreenServerItem, AddRef), asCALL_THISCALL);

--- a/Sources/ScriptBindings/ModsScreenHelper.cpp
+++ b/Sources/ScriptBindings/ModsScreenHelper.cpp
@@ -1,0 +1,116 @@
+/*
+ Copyright (c) 2026 Fran6nd, ZeroSpades developers.
+
+ This file is part of ZeroSpades, a fork of OpenSpades.
+
+ ZeroSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ZeroSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include "ScriptManager.h"
+#include <Gui/ModsScreenHelper.h>
+
+namespace spades {
+	static gui::ModsScreenHelper* CreateModsScreenHelper() { return new gui::ModsScreenHelper(); }
+
+	class ModsScreenHelperRegistrar : public ScriptObjectRegistrar {
+	public:
+		ModsScreenHelperRegistrar() : ScriptObjectRegistrar("ModsScreenHelper") {}
+
+		void Register(ScriptManager* manager, Phase phase) override {
+			asIScriptEngine* eng = manager->GetEngine();
+			int r;
+			eng->SetDefaultNamespace("spades");
+			switch (phase) {
+				case PhaseObjectType:
+					r = eng->RegisterObjectType("ModsScreenHelper", 0, asOBJ_REF);
+					manager->CheckError(r);
+					break;
+				case PhaseObjectMember:
+					r = eng->RegisterObjectBehaviour(
+					  "ModsScreenHelper", asBEHAVE_FACTORY, "ModsScreenHelper@ f()",
+					  asFUNCTION(CreateModsScreenHelper), asCALL_CDECL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour(
+					  "ModsScreenHelper", asBEHAVE_ADDREF, "void f()",
+					  asMETHOD(gui::ModsScreenHelper, AddRef), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour(
+					  "ModsScreenHelper", asBEHAVE_RELEASE, "void f()",
+					  asMETHOD(gui::ModsScreenHelper, Release), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "void StartRefresh()",
+					  asMETHOD(gui::ModsScreenHelper, StartRefresh), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "bool PollRefreshState()",
+					  asMETHOD(gui::ModsScreenHelper, PollRefreshState), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "string GetRefreshMessage()",
+					  asMETHOD(gui::ModsScreenHelper, GetRefreshMessage), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "int GetRefreshTotal()",
+					  asMETHOD(gui::ModsScreenHelper, GetRefreshTotal), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "int GetRefreshDone()",
+					  asMETHOD(gui::ModsScreenHelper, GetRefreshDone), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "string GetRefreshCurrentItem()",
+					  asMETHOD(gui::ModsScreenHelper, GetRefreshCurrentItem), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "array<string>@ GetModNames()",
+					  asMETHOD(gui::ModsScreenHelper, GetModNames), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "int GetModPakCount(string)",
+					  asMETHOD(gui::ModsScreenHelper, GetModPakCount), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "int64 GetModTotalSize(string)",
+					  asMETHOD(gui::ModsScreenHelper, GetModTotalSize), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "array<string>@ GetModContents(string)",
+					  asMETHOD(gui::ModsScreenHelper, GetModContents), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "array<string>@ GetEnabledMods()",
+					  asMETHOD(gui::ModsScreenHelper, GetEnabledMods), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "void EnableMod(string)",
+					  asMETHOD(gui::ModsScreenHelper, EnableMod), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "void DisableMod(string)",
+					  asMETHOD(gui::ModsScreenHelper, DisableMod), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ModsScreenHelper", "void ClearEnabledMods()",
+					  asMETHOD(gui::ModsScreenHelper, ClearEnabledMods), asCALL_THISCALL);
+					manager->CheckError(r);
+					break;
+				default: break;
+			}
+		}
+	};
+
+	static ModsScreenHelperRegistrar registrar;
+} // namespace spades


### PR DESCRIPTION
Basically: default paks have not moved and are no longer loaded. in app data there are now Mods (where user want to put mods to install) and user_mods (naming to be changed). Here are the pass to be loaded. When installing a pan, it will merge it into user_mods. Resetting user_mods will remove all its content and place the default paks in it. Merging multiple mods one after another overwrite files in user_mods BUT does not remove previous mods. So dead files are to be left in here. i.e. a mod that for msg has body.kv6 and another msg.kv6. The merge will keep both files.

So it is great to reset sometimes the installed mods. It is simple and reliable.

This is a draft wip.

Waiting for ideas to make it better. especially on ideas to rename user_mods.

I am thinking of adding in user_mods a history.txt that  would allow undo applying a mod by re applying all the others after a reset i.e. and also trigger an alarm to remind the user to reset sometimes like after 10 entries in the history?