### PR TITLE
ci(macos): set CMAKE_OSX_DEPLOYMENT_TARGET=12.0 so builds run on macO…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
   build-macos-intel:
     name: Build (macOS Intel)
     runs-on: macos-14
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -116,8 +118,8 @@ jobs:
           path: |
             vcpkg/installed
             vcpkg/buildtrees
-          key: macos-intel-${{ hashFiles('vcpkg_x86_64-darwin.txt', '.gitmodules') }}
-          restore-keys: macos-intel-
+          key: macos-intel-osx12-${{ hashFiles('vcpkg_x86_64-darwin.txt', '.gitmodules') }}
+          restore-keys: macos-intel-osx12-
 
       - name: Bootstrap vcpkg
         run: vcpkg/bootstrap-vcpkg.sh -disableMetrics
@@ -134,6 +136,7 @@ jobs:
             -D CMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -D VCPKG_TARGET_TRIPLET=x64-osx \
             -D CMAKE_OSX_ARCHITECTURES=x86_64 \
+            -D CMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
             -D CMAKE_CXX_STANDARD=17
 
       - name: Build application
@@ -152,6 +155,8 @@ jobs:
   build-macos-arm:
     name: Build (macOS Apple Silicon)
     runs-on: macos-14
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -164,8 +169,8 @@ jobs:
           path: |
             vcpkg/installed
             vcpkg/buildtrees
-          key: macos-arm-${{ hashFiles('vcpkg_x86_64-darwin.txt', '.gitmodules') }}
-          restore-keys: macos-arm-
+          key: macos-arm-osx12-${{ hashFiles('vcpkg_x86_64-darwin.txt', '.gitmodules') }}
+          restore-keys: macos-arm-osx12-
 
       - name: Bootstrap vcpkg
         run: vcpkg/bootstrap-vcpkg.sh -disableMetrics
@@ -182,6 +187,7 @@ jobs:
             -D CMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -D VCPKG_TARGET_TRIPLET=arm64-osx \
             -D CMAKE_OSX_ARCHITECTURES=arm64 \
+            -D CMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
             -D CMAKE_CXX_STANDARD=17
 
       - name: Build application


### PR DESCRIPTION
…S 12+


Lower requirements