### PR TITLE
Reference: document ConfigItem and missing math globals

### DIFF
--- a/Resources/Scripts/Reference/API/ConfigItem.as
+++ b/Resources/Scripts/Reference/API/ConfigItem.as
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2026 Fran6nd, ZeroSpades developers.
+
+ This file is part of ZeroSpades, a fork of OpenSpades.
+
+ ZeroSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ ZeroSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ZeroSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+namespace spades {
+
+    /**
+     * ConfigItem provides read/write access to a single configuration variable
+     * (cvar), such as "cg_fov". Construct one with the variable's name; an
+     * optional second argument supplies a default value that is registered if
+     * the variable does not exist yet.
+     */
+    class ConfigItem {
+        /** Creates an accessor for the named configuration variable. */
+        ConfigItem(const string &in name) {}
+
+        /**
+         * Creates an accessor for the named configuration variable, registering
+         * the given default value.
+         */
+        ConfigItem(const string &in name, const string &in defaultValue) {}
+
+        /** Sets the value from a floating-point number. */
+        ConfigItem @opAssign(float value) {}
+
+        /** Sets the value from an integer. */
+        ConfigItem @opAssign(int value) {}
+
+        /** Sets the value from a string. */
+        ConfigItem @opAssign(const string &in value) {}
+
+        /** The value interpreted as an integer. */
+        int IntValue {
+            get {}
+            set {}
+        }
+
+        /** The value interpreted as a floating-point number. */
+        float FloatValue {
+            get {}
+            set {}
+        }
+
+        /** The value as a string. */
+        string StringValue {
+            get {}
+            set {}
+        }
+
+        /** The value interpreted as a boolean. */
+        bool BoolValue {
+            get {}
+        }
+
+        /** The default value registered for this variable. */
+        string DefaultValue {
+            get {}
+        }
+
+        /** Whether the variable is unknown to the engine. */
+        bool IsUnknown {
+            get {}
+        }
+    }
+
+    /** Returns the names of all registered configuration variables. */
+    array<string> @GetAllConfigNames() {}
+
+}

--- a/Resources/Scripts/Reference/API/Math.as
+++ b/Resources/Scripts/Reference/API/Math.as
@@ -37,6 +37,45 @@ namespace spades {
     /** Retrieves a random value that lies in [0, 1]. */
     float GetRandom() {}
 
+    /** Retrieves a random integer that lies in [0, maximum). */
+    uint GetRandom(uint maximum) {}
+
+    /** Retrieves a random integer that lies in [minimum, maximum). */
+    uint GetRandom(uint minimum, uint maximum) {}
+
+    /** Retrieves a random integer that lies in [minimum, maximum). */
+    int GetRandom(int minimum, int maximum) {}
+
+    /** Retrieves a random value that lies in [minimum, maximum]. */
+    float GetRandom(float minimum, float maximum) {}
+
+    /** Converts an angle from degrees to radians. */
+    float rad(float degrees) {}
+
+    /** Converts an angle from radians to degrees. */
+    float deg(float radians) {}
+
+    /** Creates a color from hue, saturation, and value, each in [0, 1]. */
+    Vector3 HSV(float h, float s, float v) {}
+
+    /** Converts an 8-bit-per-channel sRGB color to a linear RGB color. */
+    Vector3 ConvertColorRGB(const IntVector3 @color) {}
+
+    /** Converts an 8-bit-per-channel sRGB color to a linear RGBA color. */
+    Vector4 ConvertColorRGBA(const IntVector3 @color) {}
+
+    /** Removes all newline characters from the given string. */
+    string StripNewlines(const string &in text) {}
+
+    /** Removes leading and trailing whitespace from the given string. */
+    string TrimSpaces(const string &in text) {}
+
+    /** Parses the given string as an integer. */
+    int ParseInt(const string &in text) {}
+
+    /** Parses the given string as a double-precision floating-point number. */
+    double ParseDouble(const string &in text) {}
+
     /** Represents a 3-component integral vector. */
     class IntVector3 {
         int x, y, z;


### PR DESCRIPTION
The scripting API reference under Scripts/Reference omitted several symbols that are registered in C++ and used by shipped scripts/mods:

- ConfigItem (cvar accessor) and GetAllConfigNames(), from Config.cpp.
- Math globals from MathScript.cpp: rad, deg, HSV, ConvertColorRGB, ConvertColorRGBA, StripNewlines, TrimSpaces, ParseInt, ParseDouble, and the GetRandom range overloads.

Adding these gives editors a complete predefined API [for mod development](https://github.com/zerospades/mod-workbench) (e.g. cg_* ConfigItems and HSV used by weapon skins).